### PR TITLE
Initializing 'definitions' dictionary in gen_model(...)

### DIFF
--- a/pyang/plugins/swagger.py
+++ b/pyang/plugins/swagger.py
@@ -559,7 +559,7 @@ def set_node_type_info(typedef, node):
                         node['maximum'] = int(maximum)
 
 
-def gen_model(children, tree_structure, config=True, definitions=None):
+def gen_model(children, tree_structure, config=True, definitions=dict()):
     """ Generates the swagger definition tree."""
     for child in children:
         referenced = False


### PR DESCRIPTION
If the definitions dictionary is not initialized by the caller it is set as None by default and this makes the script crash on line 673 where the dictionary is being iterated.
This PR initializes definitions dictionary as dict() by default so it can be iterated safely.